### PR TITLE
Fix minor issue with new provider version + code cleanup

### DIFF
--- a/demo/full.tfvars
+++ b/demo/full.tfvars
@@ -6,29 +6,3 @@ update_management                      = true
 network_security_group                 = true
 backup                                 = true
 spokes_count                           = 4
-# address_space_spokes = [
-#   {
-#     workload      = "app1"
-#     environment   = "dev"
-#     instance      = "001"
-#     address_space = ["10.100.10.0/24"]
-#   },
-#   {
-#     workload      = "app1"
-#     environment   = "prd"
-#     instance      = "001"
-#     address_space = ["10.100.110.0/24"]
-#   },
-#   {
-#     workload      = "app2"
-#     environment   = "dev"
-#     instance      = "001"
-#     address_space = ["10.100.11.0/24"]
-#   },
-#   {
-#     workload      = "app2"
-#     environment   = "prd"
-#     instance      = "001"
-#     address_space = ["10.100.111.0/24"]
-#   }
-# ]

--- a/demo/providers.tf
+++ b/demo/providers.tf
@@ -2,11 +2,10 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.74.0"
+      version = "~> 4.0"
     }
   }
   backend "azurerm" {
-    subscription_id      = "bfa339d4-ee2f-4040-810b-8ce1c3fb4877"
     resource_group_name  = "tfstate"
     storage_account_name = "cloud63tfstate"
     container_name       = "tfstate"
@@ -15,7 +14,6 @@ terraform {
 }
 
 provider "azurerm" {
-  subscription_id = "bfa339d4-ee2f-4040-810b-8ce1c3fb4877"
   features {
     resource_group {
       prevent_deletion_if_contains_resources = false

--- a/demo/variables.tf
+++ b/demo/variables.tf
@@ -83,30 +83,6 @@ variable "backup" {
   default = false
 }
 
-# variable "address_space_spokes" {
-#   type = list(object({
-#     workload        = string
-#     environment     = string
-#     instance        = string
-#     address_space   = list(string)
-#     virtual_machine = optional(bool, true)
-#   }))
-#   default = [
-#     {
-#       workload      = "app1"
-#       environment   = "dev"
-#       instance      = "001"
-#       address_space = ["10.100.10.0/24"]
-#     },
-#     {
-#       workload      = "app1"
-#       environment   = "prd"
-#       instance      = "001"
-#       address_space = ["10.100.110.0/24"]
-#     }
-#   ]
-# }
-
 variable "spokes_count" {
   type    = number
   default = 2

--- a/tests/main.tf
+++ b/tests/main.tf
@@ -1,5 +1,13 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
 provider "azurerm" {
-  subscription_id = "bfa339d4-ee2f-4040-810b-8ce1c3fb4877"
   features {}
 }
 


### PR DESCRIPTION
This pull request includes several updates to the Terraform configuration files to improve compatibility and clean up unused variables.

### Provider Version Update:
* [`demo/providers.tf`](diffhunk://#diff-baa5900439947f9c30a4b823b7c82df55fedc50e51cf6a723f1981448fc83995L5-L9): Updated the `azurerm` provider version to `~> 4.0` for better compatibility and features.

### Cleanup of Unused Variables:
* [`demo/full.tfvars`](diffhunk://#diff-461b28a4db101c973bac8d827036af282ea85190f40eca3da868499422eadfb2L9-L34): Removed commented-out `address_space_spokes` variable definitions to clean up the file.
* [`demo/variables.tf`](diffhunk://#diff-48c3aa483a2ddf0d2cfd61231e03e54d851be9b1e6336c8e5f777f7a222753c9L86-L109): Removed the commented-out `address_space_spokes` variable block.

### Subscription ID Removal:
* [`demo/providers.tf`](diffhunk://#diff-baa5900439947f9c30a4b823b7c82df55fedc50e51cf6a723f1981448fc83995L18): Removed the hardcoded `subscription_id` from the `terraform` and `provider "azurerm"` blocks.
* [`tests/main.tf`](diffhunk://#diff-4e2a69ff168330fbfa3acdcf8839f73d73a50a9b10bcd1bf0567166bc37b91e3R1-L2): Removed the hardcoded `subscription_id` from the `provider "azurerm"` block.