### PR TITLE
Update provider version in the doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/examples/main/main.tf
+++ b/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/application_gateway/README.md
+++ b/modules/application_gateway/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/application_gateway/examples/main/main.tf
+++ b/modules/application_gateway/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/backup_policy_vm/README.md
+++ b/modules/backup_policy_vm/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/backup_policy_vm/examples/main/main.tf
+++ b/modules/backup_policy_vm/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/bastion_host/README.md
+++ b/modules/bastion_host/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/bastion_host/examples/main/main.tf
+++ b/modules/bastion_host/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/firewall/README.md
+++ b/modules/firewall/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/firewall/examples/main/main.tf
+++ b/modules/firewall/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/firewall_policy/README.md
+++ b/modules/firewall_policy/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/firewall_policy/examples/main/main.tf
+++ b/modules/firewall_policy/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/firewall_policy_rule_collection_group/README.md
+++ b/modules/firewall_policy_rule_collection_group/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/firewall_policy_rule_collection_group/examples/main/main.tf
+++ b/modules/firewall_policy_rule_collection_group/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/firewall_workbook/README.md
+++ b/modules/firewall_workbook/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/firewall_workbook/examples/main/main.tf
+++ b/modules/firewall_workbook/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/key_vault/README.md
+++ b/modules/key_vault/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/key_vault/examples/main/main.tf
+++ b/modules/key_vault/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/key_vault_secret/README.md
+++ b/modules/key_vault_secret/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/key_vault_secret/examples/main/main.tf
+++ b/modules/key_vault_secret/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/linux_virtual_machine/README.md
+++ b/modules/linux_virtual_machine/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/linux_virtual_machine/examples/main/main.tf
+++ b/modules/linux_virtual_machine/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/local_network_gateway/README.md
+++ b/modules/local_network_gateway/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/local_network_gateway/examples/main/main.tf
+++ b/modules/local_network_gateway/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/log_analytics_workspace/README.md
+++ b/modules/log_analytics_workspace/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/log_analytics_workspace/examples/main/main.tf
+++ b/modules/log_analytics_workspace/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/maintenance_configuration/README.md
+++ b/modules/maintenance_configuration/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/maintenance_configuration/examples/main/main.tf
+++ b/modules/maintenance_configuration/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/monitor_data_collection_rule_association/README.md
+++ b/modules/monitor_data_collection_rule_association/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/monitor_data_collection_rule_association/examples/main/main.tf
+++ b/modules/monitor_data_collection_rule_association/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/monitor_diagnostic_setting/README.md
+++ b/modules/monitor_diagnostic_setting/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/monitor_diagnostic_setting/examples/main/main.tf
+++ b/modules/monitor_diagnostic_setting/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/network_interface/README.md
+++ b/modules/network_interface/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/network_interface/examples/main/main.tf
+++ b/modules/network_interface/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/network_security_group/README.md
+++ b/modules/network_security_group/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/network_security_group/examples/main/main.tf
+++ b/modules/network_security_group/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/network_security_rule/README.md
+++ b/modules/network_security_rule/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/network_security_rule/examples/main/main.tf
+++ b/modules/network_security_rule/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_hub/README.md
+++ b/modules/pattern_hub/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_hub/examples/main/main.tf
+++ b/modules/pattern_hub/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_hub_and_spoke/README.md
+++ b/modules/pattern_hub_and_spoke/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_hub_and_spoke/examples/main/main.tf
+++ b/modules/pattern_hub_and_spoke/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_monitoring/README.md
+++ b/modules/pattern_monitoring/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_monitoring/examples/main/main.tf
+++ b/modules/pattern_monitoring/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_routing/README.md
+++ b/modules/pattern_routing/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_routing/examples/main/main.tf
+++ b/modules/pattern_routing/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_spoke/README.md
+++ b/modules/pattern_spoke/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_spoke/examples/main/main.tf
+++ b/modules/pattern_spoke/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_spoke_dmz/README.md
+++ b/modules/pattern_spoke_dmz/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_spoke_dmz/examples/main/main.tf
+++ b/modules/pattern_spoke_dmz/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_spoke_dns/README.md
+++ b/modules/pattern_spoke_dns/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_spoke_dns/examples/main/main.tf
+++ b/modules/pattern_spoke_dns/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_spoke_jumphost/README.md
+++ b/modules/pattern_spoke_jumphost/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_spoke_jumphost/examples/main/main.tf
+++ b/modules/pattern_spoke_jumphost/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_standalone_site/README.md
+++ b/modules/pattern_standalone_site/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_standalone_site/examples/main/main.tf
+++ b/modules/pattern_standalone_site/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_vpn_connection/README.md
+++ b/modules/pattern_vpn_connection/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/pattern_vpn_connection/examples/main/main.tf
+++ b/modules/pattern_vpn_connection/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/private_dns_resolver/README.md
+++ b/modules/private_dns_resolver/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/private_dns_resolver/examples/main/main.tf
+++ b/modules/private_dns_resolver/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/private_dns_resolver_dns_forwarding_ruleset/README.md
+++ b/modules/private_dns_resolver_dns_forwarding_ruleset/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/private_dns_resolver_dns_forwarding_ruleset/examples/main/main.tf
+++ b/modules/private_dns_resolver_dns_forwarding_ruleset/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/private_dns_resolver_forwarding_rule/README.md
+++ b/modules/private_dns_resolver_forwarding_rule/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/private_dns_resolver_forwarding_rule/examples/main/main.tf
+++ b/modules/private_dns_resolver_forwarding_rule/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/private_dns_zone/README.md
+++ b/modules/private_dns_zone/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/private_dns_zone/examples/main/main.tf
+++ b/modules/private_dns_zone/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/public_ip/README.md
+++ b/modules/public_ip/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/public_ip/examples/main/main.tf
+++ b/modules/public_ip/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/recovery_services_vault/README.md
+++ b/modules/recovery_services_vault/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/recovery_services_vault/examples/main/main.tf
+++ b/modules/recovery_services_vault/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/resource_group/README.md
+++ b/modules/resource_group/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/resource_group/examples/main/main.tf
+++ b/modules/resource_group/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/route/README.md
+++ b/modules/route/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/route/examples/main/main.tf
+++ b/modules/route/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/route_table/README.md
+++ b/modules/route_table/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/route_table/examples/main/main.tf
+++ b/modules/route_table/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/storage_account/README.md
+++ b/modules/storage_account/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/storage_account/examples/main/main.tf
+++ b/modules/storage_account/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/subnet/README.md
+++ b/modules/subnet/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/subnet/examples/main/main.tf
+++ b/modules/subnet/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/subnet_network_security_group_association/README.md
+++ b/modules/subnet_network_security_group_association/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/subnet_network_security_group_association/examples/main/main.tf
+++ b/modules/subnet_network_security_group_association/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/subnet_route_table_association/README.md
+++ b/modules/subnet_route_table_association/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/subnet_route_table_association/examples/main/main.tf
+++ b/modules/subnet_route_table_association/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/user_assigned_identity/README.md
+++ b/modules/user_assigned_identity/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/user_assigned_identity/examples/main/main.tf
+++ b/modules/user_assigned_identity/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/virtual_machine_extension/README.md
+++ b/modules/virtual_machine_extension/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/virtual_machine_extension/examples/main/main.tf
+++ b/modules/virtual_machine_extension/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/virtual_network/README.md
+++ b/modules/virtual_network/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/virtual_network/examples/main/main.tf
+++ b/modules/virtual_network/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/virtual_network_gateway/README.md
+++ b/modules/virtual_network_gateway/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/virtual_network_gateway/examples/main/main.tf
+++ b/modules/virtual_network_gateway/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/virtual_network_gateway_connection/README.md
+++ b/modules/virtual_network_gateway_connection/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/virtual_network_gateway_connection/examples/main/main.tf
+++ b/modules/virtual_network_gateway_connection/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/virtual_network_peering/README.md
+++ b/modules/virtual_network_peering/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/virtual_network_peering/examples/main/main.tf
+++ b/modules/virtual_network_peering/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/virtual_network_peerings/README.md
+++ b/modules/virtual_network_peerings/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/virtual_network_peerings/examples/main/main.tf
+++ b/modules/virtual_network_peerings/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/web_application_firewall_policy/README.md
+++ b/modules/web_application_firewall_policy/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/web_application_firewall_policy/examples/main/main.tf
+++ b/modules/web_application_firewall_policy/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/windows_virtual_machine/README.md
+++ b/modules/windows_virtual_machine/README.md
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }

--- a/modules/windows_virtual_machine/examples/main/main.tf
+++ b/modules/windows_virtual_machine/examples/main/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=3.0.0"
+      version = ">=4.0.0"
     }
   }
 }


### PR DESCRIPTION
This pull request updates the required provider version for `azurerm` across multiple Terraform configuration files to ensure compatibility with the latest features and improvements. The most important changes include updating the `azurerm` provider version from `>=3.0.0` to `>=4.0.0` in various example and module files.

Provider version updates:

* [`examples/main/main.tf`](diffhunk://#diff-c186f2dcff21f6375467634a865790b52aafd679da3e2a397b261e40921862faL6-R6): Updated `azurerm` provider version to `>=4.0.0`.
* [`modules/application_gateway/examples/main/main.tf`](diffhunk://#diff-2501e93514fa903f6818b029051a1d97e7e7441d8760f8de2b17b14627faced9L6-R6): Updated `azurerm` provider version to `>=4.0.0`.
* [`modules/backup_policy_vm/examples/main/main.tf`](diffhunk://#diff-7c3f218b121fd4e3394246e4195ade417c15ec2297ae68df7edf28b8b8552ab9L6-R6): Updated `azurerm` provider version to `>=4.0.0`.
* [`modules/bastion_host/examples/main/main.tf`](diffhunk://#diff-f448fd6b1d0092fc2f84bfe563507dfdde67f98f9243431053578413a47c15f3L6-R6): Updated `azurerm` provider version to `>=4.0.0`.
* [`modules/firewall/examples/main/main.tf`](diffhunk://#diff-a01b6610ca15a4f5ff38a9c9629d17b78a713990a8a834d628f283ad634c2977L6-R6): Updated `azurerm` provider version to `>=4.0.0`.

These changes ensure that all Terraform configurations are using the latest `azurerm` provider version, which includes important updates and fixes.