### PR TITLE
remove spls on public deploy

### DIFF
--- a/modules/pattern_spoke_ai/main.tf
+++ b/modules/pattern_spoke_ai/main.tf
@@ -422,6 +422,7 @@ resource "azurerm_private_endpoint" "search_service" {
 }
 
 resource "azurerm_search_shared_private_link_service" "search_service_storage_spls" {
+  count              = (var.private_paas || var.ip_filter)? 1 : 0
   name               = "${azurerm_search_service.this.name}-${module.storage_account.name}-spls"
   search_service_id  = azurerm_search_service.this.id
   subresource_name   = "blob"


### PR DESCRIPTION
This pull request includes a small change to the `modules/pattern_spoke_ai/main.tf` file. The change adds a conditional count to the `azurerm_search_shared_private_link_service` resource to handle private PaaS and IP filtering.

* [`modules/pattern_spoke_ai/main.tf`](diffhunk://#diff-55cc8a0a287b5115d5dbcd3333d8cd87cabde0ee30baf636b4ed0c5387e82ff0R425): Added a conditional count to the `azurerm_search_shared_private_link_service` resource to handle private PaaS and IP filtering.