### PR TITLE
Add Azure AD Application name option

### DIFF
--- a/modules/naming/README.md
+++ b/modules/naming/README.md
@@ -69,6 +69,7 @@ No modules.
 | <a name="output_automation_schedule"></a> [automation\_schedule](#output\_automation\_schedule) | Automation Schedule |
 | <a name="output_automation_variable"></a> [automation\_variable](#output\_automation\_variable) | Automation Variable |
 | <a name="output_availability_set"></a> [availability\_set](#output\_availability\_set) | Availability Set |
+| <a name="output_azuread_application"></a> [azuread\_application](#output\_azuread\_application) | Azure AD Application |
 | <a name="output_backup_policy_vm"></a> [backup\_policy\_vm](#output\_backup\_policy\_vm) | Backup Policy VM |
 | <a name="output_bastion_host"></a> [bastion\_host](#output\_bastion\_host) | Bastion Host |
 | <a name="output_batch_account"></a> [batch\_account](#output\_batch\_account) | Batch Account |

--- a/modules/naming/main.tf
+++ b/modules/naming/main.tf
@@ -216,7 +216,7 @@ locals {
       max_length  = 80
       scope       = "global"
       regex       = "^[a-zA-Z0-9][a-zA-Z0-9-_.]+[a-zA-Z0-9_]$"
-    }    
+    }
     backup_policy_vm = {
       name        = substr(join("-", compact([local.prefix, "bpvm", local.suffix])), 0, 80)
       name_unique = substr(join("-", compact([local.prefix, "bpvm", local.suffix_unique])), 0, 80)
@@ -2595,7 +2595,7 @@ locals {
     }
     azuread_application = {
       valid_name        = length(regexall(local.az.azuread_application.regex, local.az.azuread_application.name)) > 0 && length(local.az.azuread_application.name) > local.az.azuread_application.min_length
-      valid_name_unique = length(regexall(local.az.azuread_application.regex, local.az.azuread_application.name_unique)) > 0      
+      valid_name_unique = length(regexall(local.az.azuread_application.regex, local.az.azuread_application.name_unique)) > 0
     }
     bastion_host = {
       valid_name        = length(regexall(local.az.bastion_host.regex, local.az.bastion_host.name)) > 0 && length(local.az.bastion_host.name) > local.az.bastion_host.min_length

--- a/modules/naming/main.tf
+++ b/modules/naming/main.tf
@@ -207,6 +207,16 @@ locals {
       scope       = "resourceGroup"
       regex       = "^[a-zA-Z0-9][a-zA-Z0-9-_.]+[a-zA-Z0-9_]$"
     }
+    azuread_application = {
+      name        = substr(join("-", compact([local.prefix, "adapp", local.suffix])), 0, 80)
+      name_unique = substr(join("-", compact([local.prefix, "adapp", local.suffix_unique])), 0, 80)
+      dashes      = true
+      slug        = "adapp"
+      min_length  = 1
+      max_length  = 80
+      scope       = "global"
+      regex       = "^[a-zA-Z0-9][a-zA-Z0-9-_.]+[a-zA-Z0-9_]$"
+    }    
     backup_policy_vm = {
       name        = substr(join("-", compact([local.prefix, "bpvm", local.suffix])), 0, 80)
       name_unique = substr(join("-", compact([local.prefix, "bpvm", local.suffix_unique])), 0, 80)
@@ -2582,6 +2592,10 @@ locals {
     availability_set = {
       valid_name        = length(regexall(local.az.availability_set.regex, local.az.availability_set.name)) > 0 && length(local.az.availability_set.name) > local.az.availability_set.min_length
       valid_name_unique = length(regexall(local.az.availability_set.regex, local.az.availability_set.name_unique)) > 0
+    }
+    azuread_application = {
+      valid_name        = length(regexall(local.az.azuread_application.regex, local.az.azuread_application.name)) > 0 && length(local.az.azuread_application.name) > local.az.azuread_application.min_length
+      valid_name_unique = length(regexall(local.az.azuread_application.regex, local.az.azuread_application.name_unique)) > 0      
     }
     bastion_host = {
       valid_name        = length(regexall(local.az.bastion_host.regex, local.az.bastion_host.name)) > 0 && length(local.az.bastion_host.name) > local.az.bastion_host.min_length

--- a/modules/naming/outputs.tf
+++ b/modules/naming/outputs.tf
@@ -98,6 +98,11 @@ output "availability_set" {
   description = "Availability Set"
 }
 
+output "azuread_application" {
+  value       = local.az.azuread_application
+  description = "Azure AD Application"
+}
+
 output "backup_policy_vm" {
   value       = local.az.backup_policy_vm
   description = "Backup Policy VM"


### PR DESCRIPTION
This pull request introduces support for naming Azure AD applications in the Terraform module. The most important changes include adding a new local variable for Azure AD applications, updating validation logic, and creating an output for Azure AD applications.

### Support for Azure AD applications:

* [`modules/naming/main.tf`](diffhunk://#diff-fde5e1f7681875d5d62a990f310682f2e79f1a6e2352d9847880b81d6edae53cR210-R219): Added a new local variable `azuread_application` with properties such as `name`, `name_unique`, `dashes`, `slug`, `min_length`, `max_length`, `scope`, and `regex`.
* [`modules/naming/main.tf`](diffhunk://#diff-fde5e1f7681875d5d62a990f310682f2e79f1a6e2352d9847880b81d6edae53cR2596-R2599): Updated the validation logic to include `azuread_application` with checks for `valid_name` and `valid_name_unique`.

### Outputs:

* [`modules/naming/outputs.tf`](diffhunk://#diff-66e754ad26afb9e412092732c3ab901ee46a50f36bd54bd3188ca981d1d1420bR101-R105): Added a new output `azuread_application` to expose the Azure AD application naming information.