### PR TITLE
Tflint

### DIFF
--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -1,9 +1,6 @@
 name: Lint
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-
+  workflow_dispatch:
 jobs:
   tflint:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tflint.yml
+++ b/.github/workflows/tflint.yml
@@ -1,0 +1,39 @@
+name: Lint
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  tflint:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v4
+      name: Checkout source code
+
+    - uses: actions/cache@v4
+      name: Cache plugin dir
+      with:
+        path: ~/.tflint.d/plugins
+        key: ${{ matrix.os }}-tflint-${{ hashFiles('.tflint.hcl') }}
+
+    - uses: terraform-linters/setup-tflint@v4
+      name: Setup TFLint
+      with:
+        tflint_version: latest
+    - name: Show version
+      run: tflint --version
+
+    - name: Init TFLint
+      run: tflint --init
+      env:
+        # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Run TFLint
+      run: tflint -f compact


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow for linting Terraform code using TFLint. The most important changes include setting up the workflow to run on multiple operating systems, caching the plugin directory, and initializing and running TFLint.

GitHub Actions Workflow for TFLint:

* [`.github/workflows/tflint.yml`](diffhunk://#diff-e748eba38ea2a68b43c4e8c63b475bd8e1073c9d0c61d5160e265c5324a21781R1-R36): Added a new workflow named "Lint" that runs on `workflow_dispatch` and executes jobs on `ubuntu-latest`, `macos-latest`, and `windows-latest` environments.
* [`.github/workflows/tflint.yml`](diffhunk://#diff-e748eba38ea2a68b43c4e8c63b475bd8e1073c9d0c61d5160e265c5324a21781R1-R36): Included steps to checkout the source code, cache the TFLint plugin directory, set up TFLint, show the TFLint version, initialize TFLint, and run TFLint with compact formatting.