### PR TITLE
Fix DNS config on Palo Alto VNet

### DIFF
--- a/modules/pattern_hub_and_spoke/main.tf
+++ b/modules/pattern_hub_and_spoke/main.tf
@@ -25,7 +25,7 @@ locals {
 
   #dns_servers = var.dns_servers != null ? var.dns_servers : var.spoke_dns ? [module.spoke_dns[0].inbound_endpoint_ip] : []
   vnet_dns_servers = var.dns_servers != null ? var.dns_servers : var.firewall ? [module.hub.firewall_private_ip_address] : var.spoke_dns ? [module.spoke_dns[0].inbound_endpoint_ip] : []
-  hub_dns_servers  = var.dns_servers != null ? var.dns_servers : var.spoke_dns ? [module.spoke_dns[0].inbound_endpoint_ip] : []
+  hub_dns_servers  = var.dns_servers != null ? var.dns_servers : (var.spoke_dns && !var.firewall_palo_alto) ? [module.spoke_dns[0].inbound_endpoint_ip] : []
 }
 
 module "locations" {


### PR DESCRIPTION
This pull request includes a change to the `modules/pattern_hub_and_spoke/main.tf` file, specifically within the `locals` block. The change updates the condition for setting the `hub_dns_servers` variable to account for an additional condition related to `firewall_palo_alto`.

Key change:

* [`modules/pattern_hub_and_spoke/main.tf`](diffhunk://#diff-7bfb9789549476d8acc20f9f7ca1c229f3c69657f0fa9f2720db1416c27223a2L28-R28): Updated the `hub_dns_servers` variable to include a check for `firewall_palo_alto`, ensuring that the `spoke_dns` is only used if `firewall_palo_alto` is not set.