### PR TITLE
Add delegation for application gateway in subnet module

### DIFF
--- a/modules/pattern_spoke_dmz/main.tf
+++ b/modules/pattern_spoke_dmz/main.tf
@@ -53,7 +53,7 @@ module "subnet" {
   address_prefixes     = [var.address_space[0]]
   delegation = {
     "applicationGateway" = {
-      name    = "Microsoft.Network/applicationGateways"
+      name = "Microsoft.Network/applicationGateways"
       actions = [
         "Microsoft.Network/virtualNetworks/subnets/join/action",
       ]


### PR DESCRIPTION
Introduce delegation for the application gateway within the subnet module to enable necessary actions for virtual network integration.