### PR TITLE
Add priority, eviction policy, and max bid price variables for VM modules

### DIFF
--- a/modules/linux_virtual_machine/README.md
+++ b/modules/linux_virtual_machine/README.md
@@ -110,11 +110,13 @@ No requirements.
 | <a name="input_enable_accelerated_networking"></a> [enable\_accelerated\_networking](#input\_enable\_accelerated\_networking) | (Optional) Should Accelerated Networking be enabled on the Network Interface? | `bool` | `false` | no |
 | <a name="input_enable_ip_forwarding"></a> [enable\_ip\_forwarding](#input\_enable\_ip\_forwarding) | (Optional) Should IP Forwarding be enabled on the Network Interface? | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | (Optional) The environment of the Virtual Network. | `string` | `""` | no |
+| <a name="input_eviction_policy"></a> [eviction\_policy](#input\_eviction\_policy) | (Optional) The eviction policy of the Virtual Machine. | `string` | `""` | no |
 | <a name="input_identity_ids"></a> [identity\_ids](#input\_identity\_ids) | (Optional) A list of Managed Service Identity IDs which should be assigned to the Virtual Machine. | `list(string)` | `[]` | no |
 | <a name="input_identity_type"></a> [identity\_type](#input\_identity\_type) | (Optional) The type of Managed Service Identity which should be used for the Virtual Machine. | `string` | `"None"` | no |
 | <a name="input_instance"></a> [instance](#input\_instance) | (Optional) The instance count for the Virtual Network. | `string` | `""` | no |
 | <a name="input_ip_configuration_name"></a> [ip\_configuration\_name](#input\_ip\_configuration\_name) | (Optional) The name of the IP Configuration. | `string` | `"ipconfig"` | no |
 | <a name="input_location"></a> [location](#input\_location) | (Required) The location/region where the Virtual Network is created. Changing this forces a new resource to be created. | `string` | n/a | yes |
+| <a name="input_max_bid_price"></a> [max\_bid\_price](#input\_max\_bid\_price) | (Optional) The maximum bid price for the Virtual Machine. | `number` | `-1` | no |
 | <a name="input_module_tags"></a> [module\_tags](#input\_module\_tags) | (Optional) Include the default tags? | `bool` | `true` | no |
 | <a name="input_monitor_agent"></a> [monitor\_agent](#input\_monitor\_agent) | (Optional) Install the Azure Monitor Agent? | `bool` | `false` | no |
 | <a name="input_monitor_agent_auto_upgrade_minor_version"></a> [monitor\_agent\_auto\_upgrade\_minor\_version](#input\_monitor\_agent\_auto\_upgrade\_minor\_version) | (Optional) Should the extension be automatically upgraded across minor versions when Azure updates the extension? | `bool` | `true` | no |
@@ -127,6 +129,7 @@ No requirements.
 | <a name="input_os_disk_type"></a> [os\_disk\_type](#input\_os\_disk\_type) | (Optional) The type of OS Disk which should be attached to the Virtual Machine. | `string` | `"Standard_LRS"` | no |
 | <a name="input_patch_assessment_mode"></a> [patch\_assessment\_mode](#input\_patch\_assessment\_mode) | (Optional) The patching configuration of the Virtual Machine. | `string` | `"ImageDefault"` | no |
 | <a name="input_patch_mode"></a> [patch\_mode](#input\_patch\_mode) | (Optional) The patching configuration of the Virtual Machine. | `string` | `"ImageDefault"` | no |
+| <a name="input_priority"></a> [priority](#input\_priority) | (Optional) The priority of the Virtual Machine. | `string` | `"Regular"` | no |
 | <a name="input_private_ip_address_allocation"></a> [private\_ip\_address\_allocation](#input\_private\_ip\_address\_allocation) | (Optional) The allocation method of the Private IP Address. | `string` | `"Dynamic"` | no |
 | <a name="input_random_password_length"></a> [random\_password\_length](#input\_random\_password\_length) | (Optional) The length of the auto-generated password. | `number` | `16` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Required) The name of the resource group in which to create the Virtual Network. | `string` | n/a | yes |

--- a/modules/linux_virtual_machine/README.md
+++ b/modules/linux_virtual_machine/README.md
@@ -110,7 +110,7 @@ No requirements.
 | <a name="input_enable_accelerated_networking"></a> [enable\_accelerated\_networking](#input\_enable\_accelerated\_networking) | (Optional) Should Accelerated Networking be enabled on the Network Interface? | `bool` | `false` | no |
 | <a name="input_enable_ip_forwarding"></a> [enable\_ip\_forwarding](#input\_enable\_ip\_forwarding) | (Optional) Should IP Forwarding be enabled on the Network Interface? | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | (Optional) The environment of the Virtual Network. | `string` | `""` | no |
-| <a name="input_eviction_policy"></a> [eviction\_policy](#input\_eviction\_policy) | (Optional) The eviction policy of the Virtual Machine. | `string` | `""` | no |
+| <a name="input_eviction_policy"></a> [eviction\_policy](#input\_eviction\_policy) | (Optional) The eviction policy of the Virtual Machine. | `string` | `"Deallocate"` | no |
 | <a name="input_identity_ids"></a> [identity\_ids](#input\_identity\_ids) | (Optional) A list of Managed Service Identity IDs which should be assigned to the Virtual Machine. | `list(string)` | `[]` | no |
 | <a name="input_identity_type"></a> [identity\_type](#input\_identity\_type) | (Optional) The type of Managed Service Identity which should be used for the Virtual Machine. | `string` | `"None"` | no |
 | <a name="input_instance"></a> [instance](#input\_instance) | (Optional) The instance count for the Virtual Network. | `string` | `""` | no |

--- a/modules/linux_virtual_machine/main.tf
+++ b/modules/linux_virtual_machine/main.tf
@@ -71,6 +71,9 @@ resource "azurerm_linux_virtual_machine" "this" {
   patch_mode                                             = var.patch_mode
   patch_assessment_mode                                  = var.patch_assessment_mode
   bypass_platform_safety_checks_on_user_schedule_enabled = var.patch_mode == "AutomaticByPlatform" ? true : false
+  priority                                               = var.priority
+  eviction_policy                                        = var.eviction_policy
+  max_bid_price                                          = var.max_bid_price
   boot_diagnostics {}
   os_disk {
     name                 = coalesce(var.custom_os_disk_name, "${module.naming.linux_virtual_machine.name}-dsk")

--- a/modules/linux_virtual_machine/variables.tf
+++ b/modules/linux_virtual_machine/variables.tf
@@ -169,6 +169,24 @@ variable "identity_ids" {
   default     = []
 }
 
+variable "priority" {
+  description = "(Optional) The priority of the Virtual Machine."
+  type        = string
+  default     = "Regular"
+}
+
+variable "eviction_policy" {
+  description = "(Optional) The eviction policy of the Virtual Machine."
+  type        = string
+  default     = ""
+}
+
+variable "max_bid_price" {
+  description = "(Optional) The maximum bid price for the Virtual Machine."
+  type        = number
+  default     = -1
+}
+
 variable "run_bootstrap" {
   description = "(Optional) Run the bootstrap script?"
   type        = bool
@@ -246,7 +264,6 @@ variable "dependency_agent_auto_upgrade_minor_version" {
   type        = bool
   default     = true
 }
-
 
 variable "watcher_agent" {
   description = "(Optional) Install the Azure Monitor Agent?"

--- a/modules/linux_virtual_machine/variables.tf
+++ b/modules/linux_virtual_machine/variables.tf
@@ -178,7 +178,7 @@ variable "priority" {
 variable "eviction_policy" {
   description = "(Optional) The eviction policy of the Virtual Machine."
   type        = string
-  default     = ""
+  default     = "Deallocate"
 }
 
 variable "max_bid_price" {

--- a/modules/windows_virtual_machine/README.md
+++ b/modules/windows_virtual_machine/README.md
@@ -109,12 +109,14 @@ No requirements.
 | <a name="input_enable_accelerated_networking"></a> [enable\_accelerated\_networking](#input\_enable\_accelerated\_networking) | (Optional) Should Accelerated Networking be enabled on the Network Interface? | `bool` | `false` | no |
 | <a name="input_enable_ip_forwarding"></a> [enable\_ip\_forwarding](#input\_enable\_ip\_forwarding) | (Optional) Should IP Forwarding be enabled on the Network Interface? | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | (Optional) The environment of the Virtual Network. | `string` | `""` | no |
+| <a name="input_eviction_policy"></a> [eviction\_policy](#input\_eviction\_policy) | (Optional) The eviction policy of the Virtual Machine. | `string` | `""` | no |
 | <a name="input_identity_ids"></a> [identity\_ids](#input\_identity\_ids) | (Optional) A list of Managed Service Identity IDs which should be assigned to the Virtual Machine. | `list(string)` | `[]` | no |
 | <a name="input_identity_type"></a> [identity\_type](#input\_identity\_type) | (Optional) The type of Managed Service Identity which should be used for the Virtual Machine. | `string` | `"None"` | no |
 | <a name="input_instance"></a> [instance](#input\_instance) | (Optional) The instance count for the Virtual Network. | `string` | `""` | no |
 | <a name="input_ip_configuration_name"></a> [ip\_configuration\_name](#input\_ip\_configuration\_name) | (Optional) The name of the IP Configuration. | `string` | `"ipconfig"` | no |
 | <a name="input_license_type"></a> [license\_type](#input\_license\_type) | (Optional) The license type which should be used for the Virtual Machine. | `string` | `"None"` | no |
 | <a name="input_location"></a> [location](#input\_location) | (Required) The location/region where the Virtual Network is created. Changing this forces a new resource to be created. | `string` | n/a | yes |
+| <a name="input_max_bid_price"></a> [max\_bid\_price](#input\_max\_bid\_price) | (Optional) The maximum bid price for the Virtual Machine. | `number` | `-1` | no |
 | <a name="input_module_tags"></a> [module\_tags](#input\_module\_tags) | (Optional) Include the default tags? | `bool` | `true` | no |
 | <a name="input_monitor_agent"></a> [monitor\_agent](#input\_monitor\_agent) | (Optional) Install the Azure Monitor Agent? | `bool` | `false` | no |
 | <a name="input_monitor_agent_auto_upgrade_minor_version"></a> [monitor\_agent\_auto\_upgrade\_minor\_version](#input\_monitor\_agent\_auto\_upgrade\_minor\_version) | (Optional) Should the extension be automatically upgraded across minor versions when Azure updates the extension? | `bool` | `true` | no |
@@ -127,6 +129,7 @@ No requirements.
 | <a name="input_os_disk_type"></a> [os\_disk\_type](#input\_os\_disk\_type) | (Optional) The type of OS Disk which should be attached to the Virtual Machine. | `string` | `"Standard_LRS"` | no |
 | <a name="input_patch_assessment_mode"></a> [patch\_assessment\_mode](#input\_patch\_assessment\_mode) | (Optional) The patching configuration of the Virtual Machine. | `string` | `"ImageDefault"` | no |
 | <a name="input_patch_mode"></a> [patch\_mode](#input\_patch\_mode) | (Optional) The patching configuration of the Virtual Machine. | `string` | `"AutomaticByPlatform"` | no |
+| <a name="input_priority"></a> [priority](#input\_priority) | (Optional) The priority of the Virtual Machine. | `string` | `"Regular"` | no |
 | <a name="input_private_ip_address"></a> [private\_ip\_address](#input\_private\_ip\_address) | (Optional) The Private IP Address which should be used for this Virtual Machine. | `string` | `null` | no |
 | <a name="input_private_ip_address_allocation"></a> [private\_ip\_address\_allocation](#input\_private\_ip\_address\_allocation) | (Optional) The allocation method of the Private IP Address. | `string` | `"Dynamic"` | no |
 | <a name="input_random_password_length"></a> [random\_password\_length](#input\_random\_password\_length) | (Optional) The length of the auto-generated password. | `number` | `16` | no |

--- a/modules/windows_virtual_machine/README.md
+++ b/modules/windows_virtual_machine/README.md
@@ -109,7 +109,7 @@ No requirements.
 | <a name="input_enable_accelerated_networking"></a> [enable\_accelerated\_networking](#input\_enable\_accelerated\_networking) | (Optional) Should Accelerated Networking be enabled on the Network Interface? | `bool` | `false` | no |
 | <a name="input_enable_ip_forwarding"></a> [enable\_ip\_forwarding](#input\_enable\_ip\_forwarding) | (Optional) Should IP Forwarding be enabled on the Network Interface? | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | (Optional) The environment of the Virtual Network. | `string` | `""` | no |
-| <a name="input_eviction_policy"></a> [eviction\_policy](#input\_eviction\_policy) | (Optional) The eviction policy of the Virtual Machine. | `string` | `""` | no |
+| <a name="input_eviction_policy"></a> [eviction\_policy](#input\_eviction\_policy) | (Optional) The eviction policy of the Virtual Machine. | `string` | `"Deallocate"` | no |
 | <a name="input_identity_ids"></a> [identity\_ids](#input\_identity\_ids) | (Optional) A list of Managed Service Identity IDs which should be assigned to the Virtual Machine. | `list(string)` | `[]` | no |
 | <a name="input_identity_type"></a> [identity\_type](#input\_identity\_type) | (Optional) The type of Managed Service Identity which should be used for the Virtual Machine. | `string` | `"None"` | no |
 | <a name="input_instance"></a> [instance](#input\_instance) | (Optional) The instance count for the Virtual Network. | `string` | `""` | no |

--- a/modules/windows_virtual_machine/main.tf
+++ b/modules/windows_virtual_machine/main.tf
@@ -73,6 +73,9 @@ resource "azurerm_windows_virtual_machine" "this" {
   bypass_platform_safety_checks_on_user_schedule_enabled = var.patch_mode == "AutomaticByPlatform" ? true : false
   license_type                                           = var.license_type
   vm_agent_platform_updates_enabled                      = var.vm_agent_platform_updates_enabled
+  priority                                               = var.priority
+  eviction_policy                                        = var.eviction_policy
+  max_bid_price                                          = var.max_bid_price
   boot_diagnostics {}
   os_disk {
     name                 = coalesce(var.custom_os_disk_name, "${module.naming.windows_virtual_machine.name}-dsk")

--- a/modules/windows_virtual_machine/variables.tf
+++ b/modules/windows_virtual_machine/variables.tf
@@ -187,6 +187,24 @@ variable "identity_ids" {
   default     = []
 }
 
+variable "priority" {
+  description = "(Optional) The priority of the Virtual Machine."
+  type        = string
+  default     = "Regular"
+}
+
+variable "eviction_policy" {
+  description = "(Optional) The eviction policy of the Virtual Machine."
+  type        = string
+  default     = ""
+}
+
+variable "max_bid_price" {
+  description = "(Optional) The maximum bid price for the Virtual Machine."
+  type        = number
+  default     = -1
+}
+
 variable "monitor_agent" {
   description = "(Optional) Install the Azure Monitor Agent?"
   type        = bool

--- a/modules/windows_virtual_machine/variables.tf
+++ b/modules/windows_virtual_machine/variables.tf
@@ -196,7 +196,7 @@ variable "priority" {
 variable "eviction_policy" {
   description = "(Optional) The eviction policy of the Virtual Machine."
   type        = string
-  default     = ""
+  default     = "Deallocate"
 }
 
 variable "max_bid_price" {


### PR DESCRIPTION
This pull request adds support for configuring Azure Spot Virtual Machines in both the Linux and Windows VM Terraform modules. The main changes introduce new variables and resource arguments to control VM priority, eviction policy, and bid price, enabling users to deploy Spot VMs with customizable settings.

**Spot VM support enhancements:**

* Added new variables `priority`, `eviction_policy`, and `max_bid_price` to both `linux_virtual_machine` and `windows_virtual_machine` modules, allowing users to specify these properties when creating VMs. [[1]](diffhunk://#diff-7d9738e120ba619294e7d57ce63af3e665eed50d09d17a8f40f2b319d1b97a20R172-R189) [[2]](diffhunk://#diff-7a81e4b844e7237f38c227976f0708b1fbff0576adc5217f2947acf66c8a8d1aR190-R207)
* Updated the `azurerm_linux_virtual_machine` and `azurerm_windows_virtual_machine` resources to set the `priority`, `eviction_policy`, and `max_bid_price` arguments based on the new variables. [[1]](diffhunk://#diff-d7aff04b95b42c51df94f34a6fc680d7d81eb46fcfcc4831fa512f62277fe989R74-R76) [[2]](diffhunk://#diff-8ff56812e09502704e9c4fef90854de55e3c6cc845eb1149042ecfa70ce92119R76-R78)

No other functional changes were made.