### PR TITLE
Fix 20260107

### DIFF
--- a/.github/workflows/manual-apply-ai.yml
+++ b/.github/workflows/manual-apply-ai.yml
@@ -35,6 +35,10 @@ jobs:
           az storage account update --resource-group "${sa[3]}" --name "${sa[7]}" --public-network-access Enabled
         shell: bash
 
+      - name: Wait for firewall rules to propagate
+        run: sleep 30
+        shell: bash
+
       - name: Terraform Init 
         id: init
         run: terraform -chdir=demo init

--- a/.github/workflows/manual-apply-custom.yml
+++ b/.github/workflows/manual-apply-custom.yml
@@ -91,6 +91,10 @@ jobs:
           az storage account update --resource-group "${sa[3]}" --name "${sa[7]}" --public-network-access Enabled
         shell: bash
 
+      - name: Wait for firewall rules to propagate
+        run: sleep 30
+        shell: bash
+
       - name: Terraform Init
         id: init
         run: terraform -chdir=demo init

--- a/.github/workflows/manual-apply-full.yml
+++ b/.github/workflows/manual-apply-full.yml
@@ -35,6 +35,10 @@ jobs:
           az storage account update --resource-group "${sa[3]}" --name "${sa[7]}" --public-network-access Enabled
         shell: bash
 
+      - name: Wait for firewall rules to propagate
+        run: sleep 30
+        shell: bash
+
       - name: Terraform Init 
         id: init
         run: terraform -chdir=demo init

--- a/.github/workflows/manual-apply-mini.yml
+++ b/.github/workflows/manual-apply-mini.yml
@@ -35,6 +35,10 @@ jobs:
           az storage account update --resource-group "${sa[3]}" --name "${sa[7]}" --public-network-access Enabled
         shell: bash
 
+      - name: Wait for firewall rules to propagate
+        run: sleep 30
+        shell: bash
+
       - name: Terraform Init 
         id: init
         run: terraform -chdir=demo init

--- a/.github/workflows/manual-apply-onprem.yml
+++ b/.github/workflows/manual-apply-onprem.yml
@@ -35,6 +35,10 @@ jobs:
           az storage account update --resource-group "${sa[3]}" --name "${sa[7]}" --public-network-access Enabled
         shell: bash
 
+      - name: Wait for firewall rules to propagate
+        run: sleep 30
+        shell: bash
+
       - name: Terraform Init 
         id: init
         run: terraform -chdir=demo init

--- a/.github/workflows/manual-apply-palo-alto.yml
+++ b/.github/workflows/manual-apply-palo-alto.yml
@@ -35,6 +35,10 @@ jobs:
           az storage account update --resource-group "${sa[3]}" --name "${sa[7]}" --public-network-access Enabled
         shell: bash
 
+      - name: Wait for firewall rules to propagate
+        run: sleep 30
+        shell: bash
+
       - name: Terraform Init 
         id: init
         run: terraform -chdir=demo init

--- a/.github/workflows/manual-apply-standard.yml
+++ b/.github/workflows/manual-apply-standard.yml
@@ -35,6 +35,10 @@ jobs:
           az storage account update --resource-group "${sa[3]}" --name "${sa[7]}" --public-network-access Enabled
         shell: bash   
 
+      - name: Wait for firewall rules to propagate
+        run: sleep 30
+        shell: bash
+
       - name: Terraform Init 
         id: init
         run: terraform -chdir=demo init

--- a/.github/workflows/manual-destroy.yml
+++ b/.github/workflows/manual-destroy.yml
@@ -37,6 +37,10 @@ jobs:
           az storage account update --resource-group "${sa[3]}" --name "${sa[7]}" --public-network-access Enabled
         shell: bash        
 
+      - name: Wait for firewall rules to propagate
+        run: sleep 30
+        shell: bash
+
       - name: Terraform Init 
         id: init
         run: terraform -chdir=demo init

--- a/modules/linux_virtual_machine/main.tf
+++ b/modules/linux_virtual_machine/main.tf
@@ -72,7 +72,7 @@ resource "azurerm_linux_virtual_machine" "this" {
   patch_assessment_mode                                  = var.patch_assessment_mode
   bypass_platform_safety_checks_on_user_schedule_enabled = var.patch_mode == "AutomaticByPlatform" ? true : false
   priority                                               = var.priority
-  eviction_policy                                        = var.eviction_policy
+  eviction_policy                                        = var.priority == "Spot" ? var.eviction_policy : null
   max_bid_price                                          = var.max_bid_price
   boot_diagnostics {}
   os_disk {

--- a/modules/windows_virtual_machine/README.md
+++ b/modules/windows_virtual_machine/README.md
@@ -141,7 +141,6 @@ No requirements.
 | <a name="input_source_image_reference_version"></a> [source\_image\_reference\_version](#input\_source\_image\_reference\_version) | (Optional) The version of the image which should be used for the Virtual Machine. | `string` | `"latest"` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | (Required) The ID of the Subnet which should be used with the Network Interface. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the resource. | `map(string)` | `null` | no |
-| <a name="input_vm_agent_platform_updates_enabled"></a> [vm\_agent\_platform\_updates\_enabled](#input\_vm\_agent\_platform\_updates\_enabled) | (Optional) Should the VM Agent be enabled for the Virtual Machine? | `bool` | `true` | no |
 | <a name="input_watcher_agent"></a> [watcher\_agent](#input\_watcher\_agent) | (Optional) Install the Azure Monitor Agent? | `bool` | `false` | no |
 | <a name="input_watcher_agent_auto_upgrade_minor_version"></a> [watcher\_agent\_auto\_upgrade\_minor\_version](#input\_watcher\_agent\_auto\_upgrade\_minor\_version) | (Optional) Should the extension be automatically upgraded across minor versions when Azure updates the extension? | `bool` | `true` | no |
 | <a name="input_watcher_agent_automatic_upgrade_enabled"></a> [watcher\_agent\_automatic\_upgrade\_enabled](#input\_watcher\_agent\_automatic\_upgrade\_enabled) | (Optional) Should the extension be automatically upgraded when a new version is published? | `bool` | `true` | no |

--- a/modules/windows_virtual_machine/main.tf
+++ b/modules/windows_virtual_machine/main.tf
@@ -72,9 +72,8 @@ resource "azurerm_windows_virtual_machine" "this" {
   patch_assessment_mode                                  = var.patch_assessment_mode
   bypass_platform_safety_checks_on_user_schedule_enabled = var.patch_mode == "AutomaticByPlatform" ? true : false
   license_type                                           = var.license_type
-  vm_agent_platform_updates_enabled                      = var.vm_agent_platform_updates_enabled
   priority                                               = var.priority
-  eviction_policy                                        = var.eviction_policy
+  eviction_policy                                        = var.priority == "Spot" ? var.eviction_policy : null
   max_bid_price                                          = var.max_bid_price
   boot_diagnostics {}
   os_disk {

--- a/modules/windows_virtual_machine/variables.tf
+++ b/modules/windows_virtual_machine/variables.tf
@@ -169,12 +169,6 @@ variable "license_type" {
   default     = "None"
 }
 
-variable "vm_agent_platform_updates_enabled" {
-  description = "(Optional) Should the VM Agent be enabled for the Virtual Machine?"
-  type        = bool
-  default     = true
-}
-
 variable "identity_type" {
   description = "(Optional) The type of Managed Service Identity which should be used for the Virtual Machine."
   type        = string


### PR DESCRIPTION
This pull request introduces improvements to both the GitHub Actions workflows and the Terraform modules for virtual machines. The main focus is on ensuring proper propagation of firewall rules before running Terraform operations and refining the configuration of eviction policies for spot VMs.

**Workflow reliability improvements:**

* Added a new step to all relevant GitHub Actions workflows (`manual-apply-*` and `manual-destroy.yml`) to wait 30 seconds after updating storage account firewall rules, ensuring that changes have time to propagate before initializing Terraform. [[1]](diffhunk://#diff-3b4bd5e42b7f904d6a05e06089a1335262c6940b2b881daad8e714971c093cbbR38-R41) [[2]](diffhunk://#diff-1964c21f4b39fe05bf0c89921f03ecb4de1df2bc0be381ece0bdf75b45a7c07dR94-R97) [[3]](diffhunk://#diff-6f356ac9ad22a25d1bb8232a4e5c7997895924686307e9c37551815fc5d8726fR38-R41) [[4]](diffhunk://#diff-75eeff2fe78183e79510e2eadce73fdcf7fd3a0e19900802d0b146434ad4a450R38-R41) [[5]](diffhunk://#diff-2c7a95185d21bbd37885e5357b852387f989ab30687d46eca39ba4019df05bccR38-R41) [[6]](diffhunk://#diff-1eeadfdb52b4cf16f094c998b82a643d3475a69ede9316c646f568df518a2ca7R38-R41) [[7]](diffhunk://#diff-17f335d22256ac50188b6da84cdb00359f0152c162836995749394713e502923R38-R41) [[8]](diffhunk://#diff-855a98c5384ab272e4f1b252baf563777217a953378e3c8550451ddf2b50b173R40-R43)

**Terraform VM module enhancements:**

* Updated both `azurerm_linux_virtual_machine` and `azurerm_windows_virtual_machine` resources to set `eviction_policy` only when `priority` is `"Spot"`, otherwise setting it to `null`. This prevents unnecessary configuration for non-spot VMs. [[1]](diffhunk://#diff-d7aff04b95b42c51df94f34a6fc680d7d81eb46fcfcc4831fa512f62277fe989L75-R75) [[2]](diffhunk://#diff-8ff56812e09502704e9c4fef90854de55e3c6cc845eb1149042ecfa70ce92119L75-R76)
* Removed the unused `vm_agent_platform_updates_enabled` variable from the Windows VM module for codebase simplification.